### PR TITLE
Exposes errors types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ mod errors;
 mod types;
 use types::*;
 use errors::*;
+pub use errors::{DateResult, DateError};
 
 #[derive(Clone,Copy)]
 pub enum Dialect {


### PR DESCRIPTION
Makes the error types public so that external crates can access them.
This makes it easier to work with this crate safely, as otherwise errors
cannot be analyzed by external crates.

Possible resolution to #5  
