### PR TITLE
Expose underlying duration parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,10 @@
 //!
 //! ## API
 //!
-//! There is exactly one entry point, which is given the date string, a `DateTime` from
-//! which relative dates and times operate, and a dialect (either `Dialect::Uk`
-//! or `Dialect::Us` currently.) The base time also specifies the desired timezone.
+//! There are two entry points: `parse_date_string` and `parse_duration`. The
+//! first is given the date string, a `DateTime` from which relative dates and
+//! times operate, and a dialect (either `Dialect::Uk` or `Dialect::Us`
+//! currently.) The base time also specifies the desired timezone.
 //!
 //! ```ignore
 //! extern crate chrono_english;
@@ -60,6 +61,15 @@
 //! There is a little command-line program `parse-date` in the `examples` folder which can be used to play
 //! with these expressions.
 //!
+//! The other function, `parse_duration`, lets you access just the relative part
+//! of a string like 'two days ago' or '12 hours'. If successful, returns an
+//! `Interval`, which is a number of seconds, days, or months.
+//!
+//! ```
+//! use chrono_english::{parse_duration,Interval};
+//!
+//! assert_eq!(parse_duration("15m ago").unwrap(), Interval::Seconds(-15 * 60));
+//! ```
 //!
 
 extern crate scanlex;

--- a/src/types.rs
+++ b/src/types.rs
@@ -166,6 +166,12 @@ impl AbsDate {
     }
 }
 
+/// A generic amount of time, in either seconds, days, or months.
+///
+/// This way, a user can decide how they want to treat days (which do
+/// not always have the same number of seconds) or months (which do not always
+/// have the same number of days).
+//
 // Skipping a given number of time units.
 // The subtlety is that we treat duration as seconds until we get
 // to months, where we want to preserve dates. So adding a month to

--- a/src/types.rs
+++ b/src/types.rs
@@ -171,7 +171,7 @@ impl AbsDate {
 // to months, where we want to preserve dates. So adding a month to
 // '5 May' gives '5 June'. Adding a month to '30 Jan' gives 'Feb 28' or 'Feb 29'
 // depending on whether this is a leap year.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Interval {
     Seconds(i32),
     Days(i32),
@@ -231,6 +231,16 @@ impl Skip {
                 ts.to_date_time(date.unwrap())?
             },
         })
+    }
+
+    pub fn to_interval(self) -> Interval {
+        use Interval::*;
+
+        match self.unit {
+            Seconds(s) => Seconds(s * self.skip),
+            Days(d) => Days(d * self.skip),
+            Months(m) => Months(m * self.skip),
+        }
     }
 }
 


### PR DESCRIPTION
I am in the process of rewriting a log-searching program in Rust, which it takes arguments like `--on 'Apr 1 13:00' --around '6 hours'`. This crate worked a treat for `--on`, but I really would like access to the underlying duration argument, so I added it!

I thought about returning a `Duration`, but that's fraught (because you have to deal with daylight savings, and leap seconds, and so on), so instead it just returns an `Interval`, so that the user can decide what to do with it. (In our existing log searcher, for example, a month is always 30 days and a day is always 24 hours, which is fine for our needs.)

