### PR TITLE
Derive Debuf for Dialect too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use errors::*;
 
 pub use errors::{DateResult,DateError};
 
-#[derive(Clone,Copy)]
+#[derive(Clone,Copy,Debug)]
 pub enum Dialect {
     Uk,
     Us


### PR DESCRIPTION
Without this, structs with a Dialect field can not have Debug derived.

```
   Compiling atuin-client v0.6.2 (/Users/yuvipanda/code/atuin/atuin-client)
error[E0277]: `Dialect` doesn't implement `std::fmt::Debug`
  --> atuin-client/src/settings.rs:36:5
   |
36 |     pub dialect: Dialect,
   |     ^^^^^^^^^^^^^^^^^^^^ `Dialect` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
   |
   = help: the trait `std::fmt::Debug` is not implemented for `Dialect`
   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&Dialect`
   = note: required for the cast to the object type `dyn std::fmt::Debug`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `atuin-client`
```