### PR TITLE
Update types.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ license="MIT"
 [dependencies]
 chrono = "0.4"
 scanlex = "0.1.2"
-time = "0.1"
 
 [dev-dependencies]
 lapp = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@
 //!
 
 extern crate scanlex;
-extern crate time;
 extern crate chrono;
 use chrono::prelude::*;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use chrono::prelude::*;
-use time::Duration;
+use chrono::Duration;
 
 // implements next/last direction in expressions like 'next friday' and 'last 4 july'
 #[derive(Debug,Clone,Copy,PartialEq)]
@@ -370,6 +370,3 @@ pub fn time_unit(s: &str) -> Option<Interval> {
         _ => return None
     })
 }
-
-
-


### PR DESCRIPTION
Fixed type errors in chrono-english by switching from time::Duration to chrono::Duration type
# Error message before this patch:
```
stderr: error[E0308]: mismatched types
  --> fbcode/buck-out/dev/cells/fbsource/bin/aab7ed39/third-party/rust/chrono-english#platform009-clang,rlib-pic/third-party/rust/vendor/chrono-english-0.1.6/src/types.rs:54:29
   |
54 |     base.checked_add_signed(Duration::days(days))
   |                             ^^^^^^^^^^^^^^^^^^^^ expected struct `chrono::Duration`, found struct `time::Duration`

error[E0308]: mismatched types
   --> fbcode/buck-out/dev/cells/fbsource/bin/aab7ed39/third-party/rust/chrono-english#platform009-clang,rlib-pic/third-party/rust/vendor/chrono-english-0.1.6/src/types.rs:193:21
    |
193 |                     Duration::seconds((secs as i64)*(self.skip as i64))
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `chrono::Duration`, found struct `time::Duration`

error[E0308]: mismatched types
   --> fbcode/buck-out/dev/cells/fbsource/bin/aab7ed39/third-party/rust/chrono-english#platform009-clang,rlib-pic/third-party/rust/vendor/chrono-english-0.1.6/src/types.rs:199:21
    |
199 |                     Duration::seconds((secs as i64)*(self.skip as i64))
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `chrono::Duration`, found struct `time::Duration`

error: aborting due to 3 previous errors
```

# Example script after this patch:
```
Output: Fri Apr  1 00:00:00 2022 +0000
Output: 2022-04-01T00:00:00+00:00
Output: 1648771200
Timestamp: 1648771200
```