### PR TITLE
chrono-english doesn't depend on chrono `clock` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ readme = "readme.md"
 license="MIT"
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 scanlex = "0.1.2"
 
 [dev-dependencies]
+chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }
 lapp = "0.3"
-


### PR DESCRIPTION
While the chrono-engligh tests depend on the `clock` feature, it's not used as part of the non-test chrono-english. This turns off the feature to reduce the dependencies needed by downstream libraries and applications.