### PR TITLE
Several fixes and all other PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug Report 🐛
+description: Create a report to help improve the project
+labels: ["t: bug"]
+title: "[Bug]"
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please take the time to fill out all relevant the fields below.
+
+  - type: textarea
+    id: description-of-bug
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of the bug.
+      placeholder: |
+        Description goes here :)
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Please add a code example on how to trigger the bug.
+        Or even better, a link to a repository with a minimal reproducible setup to reproduce the bug.
+      placeholder: |
+        ```
+          use chronoest_english::*;
+        ```
+        The import doesn't work!
+    validations:
+      required: true
+
+  - type: textarea
+    id: debug-output
+    attributes:
+      label: Logs (if applicable)
+      description: |
+        This is mostly important for crashes or panics.
+        Logs helps me to debug a problem if the bug is something that's not clearly visible.
+      placeholder: |
+        ```
+        Some log output here
+        ```
+    validations:
+      required: false
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system
+      description: The operating system you're using.
+      placeholder: iOS 8 / Windows 10 / Ubuntu 22.04
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: chrono-english version
+      description: The current version you're using.
+      placeholder: v6.1.4
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+      placeholder: |
+        Anything else you want to add.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: ["t: feature"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please take the time to fill out all relevant the fields below.
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: A detailed description of the feature you would like to see added.
+      description: |
+        Explain how that feature would look like and how it should behave.
+    validations:
+      required: true
+
+  - type: textarea
+    id: user-story
+    attributes:
+      label: Explain your usecase of the requested feature
+      description: |
+        I need to know what a feature is going to be used for, before I can decide if and how it's going to be implemented.
+
+        The more information you provide, the better I understand your problem ;).
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: |
+        If your problem can be solved in multiple ways, I would like to hear the possible alternatives you've considered.
+
+        Some problems really don't have any feasible alternatives, in that case don't bother answering this question :)
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+      placeholder: |
+        Anything else you want to add, such as sketches, example code, etc.
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,43 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/coverage.yml'
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/coverage.yml'
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  coverage:
+    name: Create coverage statistics
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,47 @@
+name: Code Style
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/lint.yml"
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/lint.yml"
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+jobs:
+  test:
+    name: Tests on ${{ matrix.os }} for ${{ matrix.toolchain }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: cargo build
+        run: cargo build
+
+      - name: cargo fmt
+        run: cargo fmt
+
+      - name: cargo clippy
+        run: cargo clippy --tests -- -D warnings
+
+      - name: cargo clippy without default features
+        run: cargo clippy --no-default-features --tests -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,82 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/test.yml"
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/test.yml"
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+jobs:
+  test:
+    name: Test target ${{ matrix.target }} on ${{ matrix.os }} for ${{ matrix.toolchain }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-pc-windows-msvc
+          - x86_64-apple-darwin
+          - wasm32-wasi
+        toolchain: [stable, nightly, "1.74"]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            minimal_setup: false
+          - target: wasm32-wasi
+            os: ubuntu-latest
+            minimal_setup: true
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            minimal_setup: false
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            minimal_setup: false
+
+    # minimal_setup: This is needed for targets that don't support our dev dependencies.
+    #                It also excludes the default features, i.e. [tty].
+    #                For instance, "wasm32-wasi" is such a target.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          targets: ${{ matrix.target }}
+          toolchain: ${{ matrix.toolchain }}
+          components: rustfmt, clippy
+
+      - name: cargo build
+        run: cargo build --target=${{ matrix.target }}
+        if: ${{ !matrix.minimal_setup }}
+
+      - name: cargo test
+        run: cargo test --target=${{ matrix.target }} --features=integration_test
+        if: ${{ !matrix.minimal_setup }}
+
+      - name: cargo test without default features
+        run: cargo test --target=${{ matrix.target }} --tests --no-default-features
+        if: ${{ !matrix.minimal_setup }}
+
+      - name: cargo test with crossterm re-export
+        run: cargo test --target=${{ matrix.target }} --features=integration_test,reexport_crossterm
+        if: ${{ !matrix.minimal_setup }}
+
+      - name: cargo test with custom_styling
+        run: cargo test --target=${{ matrix.target }} --features=integration_test,custom_styling
+        if: ${{ !matrix.minimal_setup }}
+
+      - name: cargo build without default features and without dev dependencies
+        run: cargo build --release --target=${{ matrix.target }} --no-default-features
+        if: ${{ matrix.minimal_setup }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ readme = "readme.md"
 license="MIT"
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 scanlex = "0.1.2"
 
 [dev-dependencies]
+chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }
 lapp = "0.3"
-

--- a/examples/parse-date.rs
+++ b/examples/parse-date.rs
@@ -1,14 +1,14 @@
 extern crate chrono_english;
-use chrono_english::{parse_date_string,Dialect};
+use chrono_english::{parse_date_string, Dialect};
 
 extern crate chrono;
 use chrono::prelude::*;
 
 extern crate lapp;
 
-use std::fmt::Display;
 use std::error::Error;
-type BoxResult<T> = Result<T,Box<dyn Error>>;
+use std::fmt::Display;
+type BoxResult<T> = Result<T, Box<dyn Error>>;
 
 const USAGE: &str = "
 Parsing Dates in English
@@ -21,15 +21,27 @@ Parsing Dates in English
 const FMT_C: &str = "%c %z";
 const FMT_ISO: &str = "%+";
 
-fn parse_and_compare<Tz: TimeZone>(datestr: &str, basestr: &str, now: DateTime<Tz>, dialect: Dialect) -> BoxResult<()>
-where Tz::Offset: Display, Tz::Offset: Copy {
+fn parse_and_compare<Tz: TimeZone>(
+    datestr: &str,
+    basestr: &str,
+    now: DateTime<Tz>,
+    dialect: Dialect,
+) -> BoxResult<()>
+where
+    Tz::Offset: Display,
+    Tz::Offset: Copy,
+{
     let def = basestr == "now";
     let base = parse_date_string(basestr, now, dialect)?;
     let date_time = parse_date_string(&datestr, base, dialect)?;
-    if ! def {
+    if !def {
         println!("base {} ({})", base.format(FMT_C), base.format(FMT_ISO));
     }
-    println!("calc {} ({})", date_time.format(FMT_C), date_time.format(FMT_ISO));
+    println!(
+        "calc {} ({})",
+        date_time.format(FMT_C),
+        date_time.format(FMT_ISO)
+    );
     Ok(())
 }
 
@@ -44,9 +56,9 @@ fn run() -> BoxResult<()> {
         Dialect::Uk
     };
     if utc {
-        parse_and_compare(&datestr,&basestr, Utc::now(), dialect)?;
+        parse_and_compare(&datestr, &basestr, Utc::now(), dialect)?;
     } else {
-        parse_and_compare(&datestr,&basestr, Local::now(), dialect)?;
+        parse_and_compare(&datestr, &basestr, Local::now(), dialect)?;
     }
 
     Ok(())
@@ -54,7 +66,7 @@ fn run() -> BoxResult<()> {
 
 fn main() {
     if let Err(e) = run() {
-        eprintln!("error: {}",e);
+        eprintln!("error: {}", e);
         std::process::exit(1);
     }
 }

--- a/examples/parse-date.rs
+++ b/examples/parse-date.rs
@@ -33,7 +33,7 @@ where
 {
     let def = basestr == "now";
     let base = parse_date_string(basestr, now, dialect)?;
-    let date_time = parse_date_string(&datestr, base, dialect)?;
+    let date_time = parse_date_string(&datestr, base.clone(), dialect)?;
     if !def {
         println!("base {} ({})", base.format(FMT_C), base.format(FMT_ISO));
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@ use scanlex::ScanError;
 use std::error::Error;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct DateError {
     details: String,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,16 +9,18 @@ pub struct DateError {
 
 impl fmt::Display for DateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,"{}",self.details)
+        write!(f, "{}", self.details)
     }
 }
 
 impl Error for DateError {}
 
-pub type DateResult<T> = Result<T,DateError>;
+pub type DateResult<T> = Result<T, DateError>;
 
 pub fn date_error(msg: &str) -> DateError {
-    DateError{details: msg.into()}
+    DateError {
+        details: msg.into(),
+    }
 }
 
 pub fn date_result<T>(msg: &str) -> DateResult<T> {
@@ -31,25 +33,21 @@ impl From<ScanError> for DateError {
     }
 }
 
-
 /// This trait maps optional values onto `DateResult`
 pub trait OrErr<T> {
     /// use when the error message is always a simple string
     fn or_err(self, msg: &str) -> DateResult<T>;
 
     /// use when the message needs to be constructed
-    fn or_then_err<C: FnOnce()->String>(self,fun:C) -> DateResult<T>;
+    fn or_then_err<C: FnOnce() -> String>(self, fun: C) -> DateResult<T>;
 }
 
-impl <T>OrErr<T> for Option<T> {
+impl<T> OrErr<T> for Option<T> {
     fn or_err(self, msg: &str) -> DateResult<T> {
         self.ok_or(date_error(msg))
     }
 
-    fn or_then_err<C: FnOnce()->String>(self,fun:C) -> DateResult<T> {
+    fn or_then_err<C: FnOnce() -> String>(self, fun: C) -> DateResult<T> {
         self.ok_or_else(|| date_error(&fun()))
     }
 }
-
-
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,9 +17,9 @@ impl Error for DateError {}
 
 pub type DateResult<T> = Result<T, DateError>;
 
-pub fn date_error(msg: &str) -> DateError {
+pub fn date_error(msg: impl ToString) -> DateError {
     DateError {
-        details: msg.into(),
+        details: msg.to_string(),
     }
 }
 
@@ -29,7 +29,7 @@ pub fn date_result<T>(msg: &str) -> DateResult<T> {
 
 impl From<ScanError> for DateError {
     fn from(err: ScanError) -> DateError {
-        date_error(&err.to_string())
+        date_error(err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,27 +72,33 @@
 //! ```
 //!
 
-extern crate scanlex;
 extern crate chrono;
+extern crate scanlex;
 use chrono::prelude::*;
 
-mod parser;
 mod errors;
+mod parser;
 mod types;
-use types::*;
 use errors::*;
+use types::*;
 
-pub use errors::{DateResult,DateError};
+pub use errors::{DateError, DateResult};
 pub use types::Interval;
 
-#[derive(Clone,Copy,Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Dialect {
     Uk,
-    Us
+    Us,
 }
 
-pub fn parse_date_string<Tz: TimeZone>(s: &str, now: DateTime<Tz>, dialect: Dialect) -> DateResult<DateTime<Tz>>
-where Tz::Offset: Copy {
+pub fn parse_date_string<Tz: TimeZone>(
+    s: &str,
+    now: DateTime<Tz>,
+    dialect: Dialect,
+) -> DateResult<DateTime<Tz>>
+where
+    Tz::Offset: Copy,
+{
     let mut dp = parser::DateParser::new(s);
     if let Dialect::Us = dialect {
         dp = dp.american_date();
@@ -105,11 +111,14 @@ where Tz::Offset: Copy {
         None => TimeSpec::new_empty(),
     };
     if tspec.offset.is_some() {
-     //   return DateTime::fix()::parse_from_rfc3339(s);
+        //   return DateTime::fix()::parse_from_rfc3339(s);
     }
     let date_time = if let Some(dspec) = d.date {
-        dspec.to_date_time(now,tspec,dp.american).or_err("bad date")?
-    } else { // no date, time set for today's date
+        dspec
+            .to_date_time(now, tspec, dp.american)
+            .or_err("bad date")?
+    } else {
+        // no date, time set for today's date
         tspec.to_date_time(now.date()).or_err("bad time")?
     };
     Ok(date_time)
@@ -147,62 +156,173 @@ mod tests {
 
     #[test]
     fn basics() {
-        let base = parse_date_string("2018-03-21 11:00",Utc::now(),Dialect::Uk).unwrap();
+        let base = parse_date_string("2018-03-21 11:00", Utc::now(), Dialect::Uk).unwrap();
 
         // Day of week - relative to today. May have a time part
-        assert_eq!(display(parse_date_string("friday",base,Dialect::Uk)),"2018-03-23T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("friday 10:30",base,Dialect::Uk)),"2018-03-23T10:30:00+00:00");
-        assert_eq!(display(parse_date_string("friday 8pm",base,Dialect::Uk)),"2018-03-23T20:00:00+00:00");
+        assert_eq!(
+            display(parse_date_string("friday", base, Dialect::Uk)),
+            "2018-03-23T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("friday 10:30", base, Dialect::Uk)),
+            "2018-03-23T10:30:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("friday 8pm", base, Dialect::Uk)),
+            "2018-03-23T20:00:00+00:00"
+        );
 
         // The day of week is the _next_ day after today, so "Tuesday" is the next Tuesday after Wednesday
-        assert_eq!(display(parse_date_string("tues",base,Dialect::Uk)),"2018-03-27T00:00:00+00:00");
+        assert_eq!(
+            display(parse_date_string("tues", base, Dialect::Uk)),
+            "2018-03-27T00:00:00+00:00"
+        );
 
         // The expression 'next Monday' is ambiguous; in the US it means the day following (same as 'Monday')
         // (This is how the `date` command interprets it)
-        assert_eq!(display(parse_date_string("next mon",base,Dialect::Us)),"2018-03-26T00:00:00+00:00");
+        assert_eq!(
+            display(parse_date_string("next mon", base, Dialect::Us)),
+            "2018-03-26T00:00:00+00:00"
+        );
         // but otherwise it means the day in the next week..
-        assert_eq!(display(parse_date_string("next mon",base,Dialect::Uk)),"2018-04-02T00:00:00+00:00");
+        assert_eq!(
+            display(parse_date_string("next mon", base, Dialect::Uk)),
+            "2018-04-02T00:00:00+00:00"
+        );
 
-        assert_eq!(display(parse_date_string("last fri 9.30",base,Dialect::Uk)),"2018-03-16T09:30:00+00:00");
+        assert_eq!(
+            display(parse_date_string("last fri 9.30", base, Dialect::Uk)),
+            "2018-03-16T09:30:00+00:00"
+        );
 
         // date expressed as month, day - relative to today. May have a time part
-        assert_eq!(display(parse_date_string("9/11",base,Dialect::Us)),"2018-09-11T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("last 9/11",base,Dialect::Us)),"2017-09-11T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("last 9/11 9am",base,Dialect::Us)),"2017-09-11T09:00:00+00:00");
-        assert_eq!(display(parse_date_string("April 1 8.30pm",base,Dialect::Uk)),"2018-04-01T20:30:00+00:00");
+        assert_eq!(
+            display(parse_date_string("9/11", base, Dialect::Us)),
+            "2018-09-11T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("last 9/11", base, Dialect::Us)),
+            "2017-09-11T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("last 9/11 9am", base, Dialect::Us)),
+            "2017-09-11T09:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("April 1 8.30pm", base, Dialect::Uk)),
+            "2018-04-01T20:30:00+00:00"
+        );
 
         // advance by time unit from today
         // without explicit time, use base time - otherwise override
-        assert_eq!(display(parse_date_string("2d",base,Dialect::Uk)),"2018-03-23T11:00:00+00:00");
-        assert_eq!(display(parse_date_string("2d 03:00",base,Dialect::Uk)),"2018-03-23T03:00:00+00:00");
-        assert_eq!(display(parse_date_string("3 weeks",base,Dialect::Uk)),"2018-04-11T11:00:00+00:00");
-        assert_eq!(display(parse_date_string("3h",base,Dialect::Uk)),"2018-03-21T14:00:00+00:00");
-        assert_eq!(display(parse_date_string("6 months",base,Dialect::Uk)),"2018-09-21T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("6 months ago",base,Dialect::Uk)),"2017-09-21T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("3 hours ago",base,Dialect::Uk)),"2018-03-21T08:00:00+00:00");
-        assert_eq!(display(parse_date_string(" -3h",base,Dialect::Uk)),"2018-03-21T08:00:00+00:00");
-        assert_eq!(display(parse_date_string(" -3 month",base,Dialect::Uk)),"2017-12-21T00:00:00+00:00");
+        assert_eq!(
+            display(parse_date_string("2d", base, Dialect::Uk)),
+            "2018-03-23T11:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("2d 03:00", base, Dialect::Uk)),
+            "2018-03-23T03:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("3 weeks", base, Dialect::Uk)),
+            "2018-04-11T11:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("3h", base, Dialect::Uk)),
+            "2018-03-21T14:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("6 months", base, Dialect::Uk)),
+            "2018-09-21T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("6 months ago", base, Dialect::Uk)),
+            "2017-09-21T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("3 hours ago", base, Dialect::Uk)),
+            "2018-03-21T08:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string(" -3h", base, Dialect::Uk)),
+            "2018-03-21T08:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string(" -3 month", base, Dialect::Uk)),
+            "2017-12-21T00:00:00+00:00"
+        );
 
         // absolute date with year, month, day - formal ISO and informal UK or US
-        assert_eq!(display(parse_date_string("2017-06-30",base,Dialect::Uk)),"2017-06-30T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("30/06/17",base,Dialect::Uk)),"2017-06-30T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("06/30/17",base,Dialect::Us)),"2017-06-30T00:00:00+00:00");
+        assert_eq!(
+            display(parse_date_string("2017-06-30", base, Dialect::Uk)),
+            "2017-06-30T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("30/06/17", base, Dialect::Uk)),
+            "2017-06-30T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("06/30/17", base, Dialect::Us)),
+            "2017-06-30T00:00:00+00:00"
+        );
 
         // may be followed by time part, formal and informal
-        assert_eq!(display(parse_date_string("2017-06-30 08:20:30",base,Dialect::Uk)),"2017-06-30T08:20:30+00:00");
-        assert_eq!(display(parse_date_string("2017-06-30 08:20:30 +02:00",base,Dialect::Uk)),"2017-06-30T06:20:30+00:00");
-        assert_eq!(display(parse_date_string("2017-06-30 08:20:30 +0200",base,Dialect::Uk)),"2017-06-30T06:20:30+00:00");
-        assert_eq!(display(parse_date_string("2017-06-30T08:20:30Z",base,Dialect::Uk)),"2017-06-30T08:20:30+00:00");
-        assert_eq!(display(parse_date_string("2017-06-30T08:20:30",base,Dialect::Uk)),"2017-06-30T08:20:30+00:00");
-        assert_eq!(display(parse_date_string("2017-06-30 8.20",base,Dialect::Uk)),"2017-06-30T08:20:00+00:00");
-        assert_eq!(display(parse_date_string("2017-06-30 8.30pm",base,Dialect::Uk)),"2017-06-30T20:30:00+00:00");
-        assert_eq!(display(parse_date_string("2017-06-30 8:30pm",base,Dialect::Uk)),"2017-06-30T20:30:00+00:00");
-        assert_eq!(display(parse_date_string("2017-06-30 2am",base,Dialect::Uk)),"2017-06-30T02:00:00+00:00");
-        assert_eq!(display(parse_date_string("30 June 2018",base,Dialect::Uk)),"2018-06-30T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("June 30, 2018",base,Dialect::Uk)),"2018-06-30T00:00:00+00:00");
-        assert_eq!(display(parse_date_string("June   30,    2018",base,Dialect::Uk)),"2018-06-30T00:00:00+00:00");
-
-
+        assert_eq!(
+            display(parse_date_string("2017-06-30 08:20:30", base, Dialect::Uk)),
+            "2017-06-30T08:20:30+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string(
+                "2017-06-30 08:20:30 +02:00",
+                base,
+                Dialect::Uk
+            )),
+            "2017-06-30T06:20:30+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string(
+                "2017-06-30 08:20:30 +0200",
+                base,
+                Dialect::Uk
+            )),
+            "2017-06-30T06:20:30+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("2017-06-30T08:20:30Z", base, Dialect::Uk)),
+            "2017-06-30T08:20:30+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("2017-06-30T08:20:30", base, Dialect::Uk)),
+            "2017-06-30T08:20:30+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("2017-06-30 8.20", base, Dialect::Uk)),
+            "2017-06-30T08:20:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("2017-06-30 8.30pm", base, Dialect::Uk)),
+            "2017-06-30T20:30:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("2017-06-30 8:30pm", base, Dialect::Uk)),
+            "2017-06-30T20:30:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("2017-06-30 2am", base, Dialect::Uk)),
+            "2017-06-30T02:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("30 June 2018", base, Dialect::Uk)),
+            "2018-06-30T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("June 30, 2018", base, Dialect::Uk)),
+            "2018-06-30T00:00:00+00:00"
+        );
+        assert_eq!(
+            display(parse_date_string("June   30,    2018", base, Dialect::Uk)),
+            "2018-06-30T00:00:00+00:00"
+        );
     }
 
     fn get_err(r: DateResult<Interval>) -> String {
@@ -212,10 +332,16 @@ mod tests {
     #[test]
     fn durations() {
         assert_eq!(parse_duration("6h").unwrap(), Interval::Seconds(6 * 3600));
-        assert_eq!(parse_duration("4 hours ago").unwrap(), Interval::Seconds(-4 * 3600));
+        assert_eq!(
+            parse_duration("4 hours ago").unwrap(),
+            Interval::Seconds(-4 * 3600)
+        );
         assert_eq!(parse_duration("5 min").unwrap(), Interval::Seconds(5 * 60));
         assert_eq!(parse_duration("10m").unwrap(), Interval::Seconds(10 * 60));
-        assert_eq!(parse_duration("15m ago").unwrap(), Interval::Seconds(-15 * 60));
+        assert_eq!(
+            parse_duration("15m ago").unwrap(),
+            Interval::Seconds(-15 * 60)
+        );
 
         assert_eq!(parse_duration("1 day").unwrap(), Interval::Days(1));
         assert_eq!(parse_duration("2 days ago").unwrap(), Interval::Days(-2));
@@ -227,9 +353,21 @@ mod tests {
         assert_eq!(parse_duration("8 years").unwrap(), Interval::Months(12 * 8));
 
         // errors
-        assert_eq!(get_err(parse_duration("2020-01-01")), "unexpected absolute date");
-        assert_eq!(get_err(parse_duration("2 days 15:00")), "unexpected time component");
-        assert_eq!(get_err(parse_duration("tuesday")), "unexpected date component");
-        assert_eq!(get_err(parse_duration("bananas")), "expected week day or month name");
+        assert_eq!(
+            get_err(parse_duration("2020-01-01")),
+            "unexpected absolute date"
+        );
+        assert_eq!(
+            get_err(parse_duration("2 days 15:00")),
+            "unexpected time component"
+        );
+        assert_eq!(
+            get_err(parse_duration("tuesday")),
+            "unexpected date component"
+        );
+        assert_eq!(
+            get_err(parse_duration("bananas")),
+            "expected week day or month name"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ mod types;
 use errors::*;
 use types::*;
 
+pub use errors::{date_error, date_result};
 pub use errors::{DateError, DateResult};
 pub use types::Interval;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub use errors::{date_error, date_result};
 pub use errors::{DateError, DateResult};
 pub use types::Interval;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Hash, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Dialect {
     Uk,
     Us,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,11 +2,11 @@ use chrono::prelude::*;
 use chrono::Duration;
 
 // implements next/last direction in expressions like 'next friday' and 'last 4 july'
-#[derive(Debug,Clone,Copy,PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Direction {
     Next,
     Last,
-    Here
+    Here,
 }
 
 impl Direction {
@@ -15,7 +15,7 @@ impl Direction {
         match s {
             "next" => Some(Next),
             "last" => Some(Last),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -32,12 +32,15 @@ pub struct YearDate {
 #[derive(Debug)]
 pub struct NamedDate {
     pub direct: Direction,
-    pub unit: u32
+    pub unit: u32,
 }
 
 impl NamedDate {
     pub fn new(direct: Direction, unit: u32) -> NamedDate {
-        NamedDate{direct: direct, unit: unit}
+        NamedDate {
+            direct: direct,
+            unit: unit,
+        }
     }
 }
 
@@ -61,8 +64,7 @@ fn next_last_direction<T: PartialOrd + Copy>(date: T, base: T, direct: Direction
         if direct == Direction::Last {
             res = Some(-1);
         }
-    } else
-    if date < base {
+    } else if date < base {
         if direct == Direction::Next {
             res = Some(1)
         }
@@ -72,31 +74,39 @@ fn next_last_direction<T: PartialOrd + Copy>(date: T, base: T, direct: Direction
 
 impl ByName {
     pub fn from_name(s: &str, direct: Direction) -> Option<ByName> {
-        Some(
-            if let Some(wd) = week_day(s) {
-                ByName::WeekDay(NamedDate::new(direct,wd))
-            } else
-            if let Some(mn) = month_name(s) {
-                ByName::MonthName(NamedDate::new(direct,mn))
-            } else {
-                return None;
-            }
-        )
+        Some(if let Some(wd) = week_day(s) {
+            ByName::WeekDay(NamedDate::new(direct, wd))
+        } else if let Some(mn) = month_name(s) {
+            ByName::MonthName(NamedDate::new(direct, mn))
+        } else {
+            return None;
+        })
     }
 
     pub fn as_month(&self) -> Option<u32> {
         match *self {
             ByName::MonthName(ref nd) => Some(nd.unit),
-            _ => None
+            _ => None,
         }
     }
 
     pub fn from_day_month(d: u32, m: u32, direct: Direction) -> ByName {
-        ByName::DayMonth(YearDate{direct: direct, day: d, month: m})
+        ByName::DayMonth(YearDate {
+            direct: direct,
+            day: d,
+            month: m,
+        })
     }
 
-    pub fn to_date_time<Tz: TimeZone>(self, base: DateTime<Tz>, ts: TimeSpec, american: bool) -> Option<DateTime<Tz>>
-    where <Tz as TimeZone>::Offset: Copy {
+    pub fn to_date_time<Tz: TimeZone>(
+        self,
+        base: DateTime<Tz>,
+        ts: TimeSpec,
+        american: bool,
+    ) -> Option<DateTime<Tz>>
+    where
+        <Tz as TimeZone>::Offset: Copy,
+    {
         let this_year = base.year();
         match self {
             ByName::WeekDay(mut nd) => {
@@ -108,49 +118,57 @@ impl ByName {
                 match nd.direct {
                     Direction::Here => nd.direct = Direction::Next,
                     Direction::Next => {
-                        if ! american {
+                        if !american {
                             extra_week = 7;
                         }
-                    },
+                    }
                     _ => (),
                 };
                 let this_day = base.weekday().num_days_from_monday() as i64;
                 let that_day = nd.unit as i64;
                 let diff_days = that_day - this_day;
-                let mut date = add_days(base,diff_days)?;
-                if let Some(correct) = next_last_direction(date,base,nd.direct) {
-                    date = add_days(date,7*correct as i64)?;
+                let mut date = add_days(base, diff_days)?;
+                if let Some(correct) = next_last_direction(date, base, nd.direct) {
+                    date = add_days(date, 7 * correct as i64)?;
                 }
                 if extra_week > 0 {
-                    date = add_days(date,extra_week)?;
+                    date = add_days(date, extra_week)?;
                 }
                 if diff_days == 0 {
                     // same day - comparing times will determine which way we swing...
                     let base_time = base.time();
-                    let this_time = NaiveTime::from_hms(ts.hour,ts.min,ts.sec);
-                    if let Some(correct) = next_last_direction(this_time,base_time,nd.direct) {
-                        date = add_days(date,7*correct as i64)?;
+                    let this_time = NaiveTime::from_hms(ts.hour, ts.min, ts.sec);
+                    if let Some(correct) = next_last_direction(this_time, base_time, nd.direct) {
+                        date = add_days(date, 7 * correct as i64)?;
                     }
                 }
                 ts.to_date_time(date.date())
-            },
+            }
             ByName::MonthName(nd) => {
-                let mut date = base.timezone().ymd_opt(this_year,nd.unit,1).single()?;
-                if let Some(correct) = next_last_direction(date,base.date(),nd.direct) {
-                    date = base.timezone().ymd_opt(this_year + correct,nd.unit,1).single()?;
+                let mut date = base.timezone().ymd_opt(this_year, nd.unit, 1).single()?;
+                if let Some(correct) = next_last_direction(date, base.date(), nd.direct) {
+                    date = base
+                        .timezone()
+                        .ymd_opt(this_year + correct, nd.unit, 1)
+                        .single()?;
                 }
                 ts.to_date_time(date)
-            },
+            }
             ByName::DayMonth(yd) => {
-                let mut date = base.timezone().ymd_opt(this_year,yd.month,yd.day).single()?;
-                if let Some(correct) = next_last_direction(date,base.date(),yd.direct) {
-                    date = base.timezone().ymd_opt(this_year + correct,yd.month,yd.day).single()?;
+                let mut date = base
+                    .timezone()
+                    .ymd_opt(this_year, yd.month, yd.day)
+                    .single()?;
+                if let Some(correct) = next_last_direction(date, base.date(), yd.direct) {
+                    date = base
+                        .timezone()
+                        .ymd_opt(this_year + correct, yd.month, yd.day)
+                        .single()?;
                 }
                 ts.to_date_time(date)
             }
         }
     }
-
 }
 
 #[derive(Debug)]
@@ -162,7 +180,9 @@ pub struct AbsDate {
 
 impl AbsDate {
     pub fn to_date<Tz: TimeZone>(self, base: DateTime<Tz>) -> Option<Date<Tz>> {
-        base.timezone().ymd_opt(self.year, self.month, self.day).single()
+        base.timezone()
+            .ymd_opt(self.year, self.month, self.day)
+            .single()
     }
 }
 
@@ -191,50 +211,54 @@ pub struct Skip {
 }
 
 impl Skip {
-    pub fn to_date_time<Tz: TimeZone>(self, base: DateTime<Tz>, ts: TimeSpec) -> Option<DateTime<Tz>> {
+    pub fn to_date_time<Tz: TimeZone>(
+        self,
+        base: DateTime<Tz>,
+        ts: TimeSpec,
+    ) -> Option<DateTime<Tz>> {
         Some(match self.unit {
             Interval::Seconds(secs) => {
-                base.checked_add_signed(
-                    Duration::seconds((secs as i64)*(self.skip as i64))
-                ).unwrap() // <--- !!!!
-            },
+                base.checked_add_signed(Duration::seconds((secs as i64) * (self.skip as i64)))
+                    .unwrap() // <--- !!!!
+            }
             Interval::Days(days) => {
-                let secs = 60*60*24*days;
-                let date = base.checked_add_signed(
-                    Duration::seconds((secs as i64)*(self.skip as i64))
-                ).unwrap();
-                if ! ts.empty() {
+                let secs = 60 * 60 * 24 * days;
+                let date = base
+                    .checked_add_signed(Duration::seconds((secs as i64) * (self.skip as i64)))
+                    .unwrap();
+                if !ts.empty() {
                     ts.to_date_time(date.date())?
                 } else {
                     date
                 }
-            },
+            }
             Interval::Months(mm) => {
-                let (y,m0,d) = (base.year(), (base.month()-1) as i32, base.day());
-                let delta = mm*self.skip;
+                let (y, m0, d) = (base.year(), (base.month() - 1) as i32, base.day());
+                let delta = mm * self.skip;
                 // our new month number
                 let mm = m0 + delta;
                 // which may run over to the next year and so forth
-                let (y,m) = if mm >= 0 {
-                    (y + mm/12, mm%12 + 1)
+                let (y, m) = if mm >= 0 {
+                    (y + mm / 12, mm % 12 + 1)
                 } else {
                     let pmm = 12 - mm;
-                    (y - pmm/12, 12 - pmm%12 + 1)
+                    (y - pmm / 12, 12 - pmm % 12 + 1)
                 };
                 // let chrono work out if the result makes sense
-                let mut date = base.timezone().ymd_opt(y,m as u32,d).single();
+                let mut date = base.timezone().ymd_opt(y, m as u32, d).single();
                 // dud dates like Feb 30 may result, so we back off...
                 let mut d = d;
                 while date.is_none() {
                     d -= 1;
-                    if d == 0 || d < 28 { // sanity check...
+                    if d == 0 || d < 28 {
+                        // sanity check...
                         eprintln!("fkd date");
                         return None;
                     }
-                    date = base.timezone().ymd_opt(y,m as u32,d).single();
+                    date = base.timezone().ymd_opt(y, m as u32, d).single();
                 }
                 ts.to_date_time(date.unwrap())?
-            },
+            }
         })
     }
 
@@ -252,36 +276,44 @@ impl Skip {
 #[derive(Debug)]
 pub enum DateSpec {
     Absolute(AbsDate), // Y M D (e.g. 2018-06-02, 4 July 2017)
-    Relative(Skip), // n U (e.g. 2min, 3 years ago, -2d)
+    Relative(Skip),    // n U (e.g. 2min, 3 years ago, -2d)
     FromName(ByName),  // (e.g. 'next fri', 'jul')
 }
 
 impl DateSpec {
     pub fn absolute(y: u32, m: u32, d: u32) -> DateSpec {
-        DateSpec::Absolute(
-            AbsDate{year: y as i32, month: m, day: d}
-        )
+        DateSpec::Absolute(AbsDate {
+            year: y as i32,
+            month: m,
+            day: d,
+        })
     }
 
     pub fn from_day_month(d: u32, m: u32, direct: Direction) -> DateSpec {
-        DateSpec::FromName(
-            ByName::from_day_month(d,m,direct)
-        )
+        DateSpec::FromName(ByName::from_day_month(d, m, direct))
     }
 
     pub fn skip(unit: Interval, n: i32) -> DateSpec {
-        DateSpec::Relative(
-           Skip{unit: unit, skip: n}
-        )
+        DateSpec::Relative(Skip {
+            unit: unit,
+            skip: n,
+        })
     }
 
-    pub fn to_date_time<Tz: TimeZone>(self, base: DateTime<Tz>, ts: TimeSpec, american: bool) -> Option<DateTime<Tz>>
-    where Tz::Offset: Copy {
+    pub fn to_date_time<Tz: TimeZone>(
+        self,
+        base: DateTime<Tz>,
+        ts: TimeSpec,
+        american: bool,
+    ) -> Option<DateTime<Tz>>
+    where
+        Tz::Offset: Copy,
+    {
         use DateSpec::*;
         match self {
             Absolute(ad) => ts.to_date_time(ad.to_date(base)?),
-            Relative(skip) => skip.to_date_time(base,ts), // might need time
-            FromName(byname) => byname.to_date_time(base,ts,american),
+            Relative(skip) => skip.to_date_time(base, ts), // might need time
+            FromName(byname) => byname.to_date_time(base, ts, american),
         }
     }
 }
@@ -298,15 +330,36 @@ pub struct TimeSpec {
 
 impl TimeSpec {
     pub fn new(hour: u32, min: u32, sec: u32, microsec: u32) -> TimeSpec {
-        TimeSpec{hour, min, sec, empty: false, offset: None, microsec }
+        TimeSpec {
+            hour,
+            min,
+            sec,
+            empty: false,
+            offset: None,
+            microsec,
+        }
     }
 
     pub fn new_with_offset(hour: u32, min: u32, sec: u32, offset: i64, microsec: u32) -> TimeSpec {
-        TimeSpec{hour, min, sec, empty: false, offset: Some(offset), microsec }
+        TimeSpec {
+            hour,
+            min,
+            sec,
+            empty: false,
+            offset: Some(offset),
+            microsec,
+        }
     }
 
     pub fn new_empty() -> TimeSpec {
-        TimeSpec{hour: 0, min: 0, sec: 0, empty: true, offset: None, microsec: 0 }
+        TimeSpec {
+            hour: 0,
+            min: 0,
+            sec: 0,
+            empty: true,
+            offset: None,
+            microsec: 0,
+        }
     }
 
     pub fn empty(&self) -> bool {
@@ -318,7 +371,7 @@ impl TimeSpec {
         if let Some(offs) = self.offset {
             let zoffset = dt.offset().clone();
             let tstamp = dt.timestamp() - offs + zoffset.fix().local_minus_utc() as i64;
-            let nd = NaiveDateTime::from_timestamp(tstamp,1000*self.microsec);
+            let nd = NaiveDateTime::from_timestamp(tstamp, 1000 * self.microsec);
             Some(DateTime::from_utc(nd, zoffset))
         } else {
             Some(dt)
@@ -334,7 +387,9 @@ pub struct DateTimeSpec {
 
 // same as chrono's 'count days from monday' convention
 pub fn week_day(s: &str) -> Option<u32> {
-    if s.len() < 3 { return None; }
+    if s.len() < 3 {
+        return None;
+    }
     Some(match &s[0..3] {
         "sun" => 6,
         "mon" => 0,
@@ -343,12 +398,14 @@ pub fn week_day(s: &str) -> Option<u32> {
         "thu" => 3,
         "fri" => 4,
         "sat" => 5,
-        _ => return None
+        _ => return None,
     })
 }
 
 pub fn month_name(s: &str) -> Option<u32> {
-    if s.len() < 3 { return None; }
+    if s.len() < 3 {
+        return None;
+    }
     Some(match &s[0..3] {
         "jan" => 1,
         "feb" => 2,
@@ -362,7 +419,7 @@ pub fn month_name(s: &str) -> Option<u32> {
         "oct" => 10,
         "nov" => 11,
         "dec" => 12,
-        _ => return None
+        _ => return None,
     })
 }
 
@@ -376,7 +433,7 @@ pub fn time_unit(s: &str) -> Option<Interval> {
             "w" => "wee",
             "d" => "day",
             "y" => "yea",
-            _ => return None
+            _ => return None,
         }
     } else {
         &s[0..3]
@@ -384,14 +441,11 @@ pub fn time_unit(s: &str) -> Option<Interval> {
     Some(match name {
         "sec" => Seconds(1),
         "min" => Seconds(60),
-        "hou" => Seconds(60*60),
+        "hou" => Seconds(60 * 60),
         "day" => Days(1),
         "wee" => Days(7),
         "mon" => Months(1),
         "yea" => Months(12),
-        _ => return None
+        _ => return None,
     })
 }
-
-
-

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,7 +55,7 @@ fn add_days<Tz: TimeZone>(base: DateTime<Tz>, days: i64) -> Option<DateTime<Tz>>
 
 //fn next_last_direction<Tz: TimeZone>(date: Date<Tz>, base: Date<Tz>, direct: Direction) -> Option<i32> {
 
-fn next_last_direction<T: PartialOrd + Copy>(date: T, base: T, direct: Direction) -> Option<i32> {
+fn next_last_direction<T: PartialOrd>(date: &T, base: &T, direct: Direction) -> Option<i32> {
     let mut res = None;
     if date > base {
         if direct == Direction::Last {
@@ -118,8 +118,8 @@ impl ByName {
                 let this_day = base.weekday().num_days_from_monday() as i64;
                 let that_day = nd.unit as i64;
                 let diff_days = that_day - this_day;
-                let mut date = add_days(base, diff_days)?;
-                if let Some(correct) = next_last_direction(date, base, nd.direct) {
+                let mut date = add_days(base.clone(), diff_days)?;
+                if let Some(correct) = next_last_direction(&date, &base, nd.direct) {
                     date = add_days(date, 7 * correct as i64)?;
                 }
                 if extra_week > 0 {
@@ -129,7 +129,7 @@ impl ByName {
                     // same day - comparing times will determine which way we swing...
                     let base_time = base.time();
                     let this_time = NaiveTime::from_hms(ts.hour, ts.min, ts.sec);
-                    if let Some(correct) = next_last_direction(this_time, base_time, nd.direct) {
+                    if let Some(correct) = next_last_direction(&this_time, &base_time, nd.direct) {
                         date = add_days(date, 7 * correct as i64)?;
                     }
                 }
@@ -137,7 +137,7 @@ impl ByName {
             }
             ByName::MonthName(nd) => {
                 let mut date = base.timezone().ymd_opt(this_year, nd.unit, 1).single()?;
-                if let Some(correct) = next_last_direction(date, base.date(), nd.direct) {
+                if let Some(correct) = next_last_direction(&date, &base.date(), nd.direct) {
                     date = base
                         .timezone()
                         .ymd_opt(this_year + correct, nd.unit, 1)
@@ -150,7 +150,7 @@ impl ByName {
                     .timezone()
                     .ymd_opt(this_year, yd.month, yd.day)
                     .single()?;
-                if let Some(correct) = next_last_direction(date, base.date(), yd.direct) {
+                if let Some(correct) = next_last_direction(&date, &base.date(), yd.direct) {
                     date = base
                         .timezone()
                         .ymd_opt(this_year + correct, yd.month, yd.day)

--- a/src/types.rs
+++ b/src/types.rs
@@ -197,7 +197,7 @@ impl AbsDate {
 // to months, where we want to preserve dates. So adding a month to
 // '5 May' gives '5 June'. Adding a month to '30 Jan' gives 'Feb 28' or 'Feb 29'
 // depending on whether this is a leap year.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Hash, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Interval {
     Seconds(i32),
     Days(i32),


### PR DESCRIPTION
Fixes #29 
Incorporates #28, #26, #25, #21

This MR does a few things for your convenience:

- Incorporate all open PRs that're currently open on this repository. They're all sensible and contain fairly simple changes. (@erickt, @tamird, @HarrisonMc555)
- Fix the current chrono compilation error
- Fix clippy lints
- Replace most of the cryptic abbreviated variable names, this is a WIP though.
- Add a CI setup for linting/formatting
- Add a few issue templates, feel free to remove them if you don't like them.
- Format the code based on Rust's `fmt`, this has already been done by @HarrissonMc555. 

Open tasks:
- Replace remaining abbreviated variable names
- Replace all deprecated chrono variables

This state seems to work, the tests pass and it can be used to publish a preliminary release that fixes most issues of the community.

@stevedonovan 
After taking a look at https://github.com/stevedonovan/chrono-english/issues/22, if you require help in releasing this crate, I would be open to hop into a call with you. I'll introduce you to a bit of nice tooling such as cargo-release and a few best-practices on how to do this :).

This would then also fix #22 and #27