### PR TITLE
Fixed handling of 12pm that would cause panics as per #24

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -289,12 +289,13 @@ impl<'a> DateParser<'a> {
     }
 
     fn am_pm(name: &str, mut hour: u32) -> DateResult<u32> {
-        if name == "pm" {
-            hour += 12;
-        } else if name != "am" {
-            return date_result("expected am or pm");
+        match name {
+            "am" if hour == 12 => Ok(0),
+            "am" => Ok(hour),
+            "pm" if hour == 12 => Ok(12),
+            "pm" => Ok(hour + 12),
+            _ => date_result("expected am or pm"),
         }
-        Ok(hour)
     }
 
     fn hour_time(name: &str, hour: u32) -> DateResult<TimeSpec> {


### PR DESCRIPTION
Changes to `parser.rs`:
- `am_pm` now only adds 12 for afternoon `hour` values that are _not_ 12 - otherwise 24 is produced for 12pm, leading to a panic in `chrono`
- `am_pm` now only keeps morning `hour` values that are _not_ 12 - 0 should be produced for 12am, rather than 12. Did not previously cause a panic, but also did not produce the correct value

Testing:
- Fix has been successfully tested and deployed on UWCS' Stardust for around 3 months, where we were having this issue previously with event start/end times